### PR TITLE
Update stataoutputhook.r

### DIFF
--- a/R/stataoutputhook.r
+++ b/R/stataoutputhook.r
@@ -6,7 +6,7 @@ stataoutputhook <- function(x, options) {
       y <- strsplit(x, "\n")[[1]]
 # print(y)
 # Remove "running profile.do"
-running <- grep("^\\.?[[:space:]]?Running[[:space:]].*profile.do", y)
+running <- grep("^\\.?[[:space:]]?[R|r]unning[[:space:]].*profile.do", y)
 if (length(running)>0) {y[running] <- sub("^\\.?[[:space:]]?Running[[:space:]].*profile.do","", y[running])}
      # print("running removed")
 # print(y)

--- a/R/stataoutputhook.r
+++ b/R/stataoutputhook.r
@@ -7,7 +7,7 @@ stataoutputhook <- function(x, options) {
 # print(y)
 # Remove "running profile.do"
 running <- grep("^\\.?[[:space:]]?[R|r]unning[[:space:]].*profile.do", y)
-if (length(running)>0) {y[running] <- sub("^\\.?[[:space:]]?Running[[:space:]].*profile.do","", y[running])}
+if (length(running)>0) {y[running] <- sub("^\\.?[[:space:]]?[R|r]unning[[:space:]].*profile.do","", y[running])}
      # print("running removed")
 # print(y)
       # Remove command echo in Stata log


### PR DESCRIPTION
Older versions of Stata display "running" instead of "Running" in the output. Remove "running profile.do" should now work with new and old versions of Stata.