### PR TITLE
Small improvement to `find_stata()` on Linux

### DIFF
--- a/R/find_stata.r
+++ b/R/find_stata.r
@@ -38,8 +38,14 @@ find_stata <- function(message=TRUE) {
     }
   } else if (.Platform$OS.type == "unix") {
 #      stataexe <- NULL
-      stataexe <- system2("which", "stata", stdout=TRUE)
-      if (message) message("Stata found at ", stataexe)
+    for (stataexe in c("stata-mp", "stata-se", "stata", "stata-ic")) {
+      stataexelnk <- Sys.which(stataexe)[[stataexe]]
+      if (stataexelnk != '') {
+        if (message) message("Stata found at ", stataexelnk)
+        break
+      }
+      else message("Stata executable ", stataexe, " not found")
+    }
   } else {
     message("Unrecognized operating system.")
   }


### PR DESCRIPTION
I started using Linux again and taking some of the discussion from #6 this hopefully improves `find_stata()` on Linux.

* I changed calling `which` from using `system2()` to using `Sys.which()`.

* I also added the additional executable names as discussed (searching in order: `stata-mp`, `stata-se`, `stata`, `stata-ic`). For info the Stata 17 directory on my Linux installation has no `stata-ic` but maybe an earlier version used that name (I'm not sure), it's contents are
    ```
    tom:/usr/local/stata17$ ls -a
    .    auto.dta  installed.170   libstata-se.so  stata     stata.lic    stata_pdf  xstata
    ..   docs      isstata.170     libstata.so     stata-mp  stata17.png  stinit     xstata-mp
    ado  inst2     libstata-mp.so  setrwxp         stata-se  stata_br     utilities  xstata-se
    ```

At the moment when I load the package it just finds the `stata` executable (which obvs I could change in the options).
