### PR TITLE
Small updates for Stata 19

### DIFF
--- a/R/find_stata.r
+++ b/R/find_stata.r
@@ -4,7 +4,7 @@ find_stata <- function(message=TRUE) {
 #  stataexe <- NULL
   for (d in c("C:/Program Files","C:/Program Files (x86)")) {
     if (stataexe=="" & dir.exists(d)) {
-      for (v in seq(18,11,-1)) {
+      for (v in seq(19,11,-1)) {
         dv <- paste(d,paste0("Stata",v), sep="/")
         if (dir.exists(dv)) {
           for (f in c("Stata", "StataIC", "StataSE", "StataMP", "StataBE",
@@ -44,7 +44,7 @@ find_stata <- function(message=TRUE) {
       }
       else
         for (d in c("/software/stata", "/usr/local/sbin", "/usr/local/bin", "/usr/sbin",
-                    "/usr/local/stata18", "/usr/local/stata17", "/usr/local/stata16",
+                    "/usr/local/stata19", "/usr/local/stata18", "/usr/local/stata17", "/usr/local/stata16",
                     "/usr/local/stata15")) {
           df <- paste(d, f, sep="/")
           if (file.exists(df)) {


### PR DESCRIPTION
Hi Doug,

I just realised that Stata 19 was released on 8<sup>th</sup> April <https://www.stata.com/new-in-stata/>, so I guess it's worth making these small updates and doing a new release on CRAN.

(Note I don't actually have access to Stata 19 yet but I have no reason to think that StataCorp. would have amended these paths [I think it will be the end of January when my Uni updates to Stata 19]. Also I have tested Statamarkdown under StataNow 18.5 - which is the rolling release of StataCorp released a while back (you get a few features that are in Stata 19 [before Stata 19 was released]) - <https://www.stata.com/statanow/> - StataNow 18.5 uses the same installation paths as Stata 18, so I can only assume that StataNow 19.# [which I don't know if they've released yet] will use the same paths as Stata 19).

All best
  Tom

