### PR TITLE
Add additional installation directories for StataNow 19

### DIFF
--- a/R/find_stata.r
+++ b/R/find_stata.r
@@ -30,7 +30,8 @@ find_stata <- function(message=TRUE) {
 }
   } else if (Sys.info()["sysname"]=="Darwin") {
 #    stataexe <- NULL
-    dv <- "/Applications/Stata"
+    dvstub <- c("/Applications/StataNow", "/Applications/Stata")
+    for (dv in dvstub) {
     if (dir.exists(dv)) {
       for (f in c("Stata", "StataSE", "StataMP", "StataIC", "StataBE")) {
         dvf <- paste(paste(paste(dv, f, sep="/"), "app", sep="."), "Contents/MacOS", f, sep="/")
@@ -40,6 +41,7 @@ find_stata <- function(message=TRUE) {
         }
         if (stataexe != "") break
       }
+    }
     }
   } else if (.Platform$OS.type == "unix") {
 #      stataexe <- NULL

--- a/R/find_stata.r
+++ b/R/find_stata.r
@@ -7,7 +7,7 @@ find_stata <- function(message=TRUE) {
     if (stataexe=="" & dir.exists(d)) {
 # if (message) packageStartupMessage("trying : ", d)
       for (v in seq(19,11,-1)) {
-        for (dirstub in c("Stata", "StataNow")){
+        for (dirstub in c("Stata", "StataNow", "StataNow19")){
           dv <- paste(d, paste0(dirstub,v), sep="/")
           if (dir.exists(dv)) {
 # if (message) packageStartupMessage("trying : ", dv)

--- a/R/find_stata.r
+++ b/R/find_stata.r
@@ -52,7 +52,7 @@ find_stata <- function(message=TRUE) {
       }
       else
         for (d in c("/software/stata", "/usr/local/sbin", "/usr/local/bin", "/usr/sbin",
-                    "/usr/local/stata19", "/usr/local/stata18", "/usr/local/stata17", "/usr/local/stata16",
+                    "/usr/local/statanow19", "/usr/local/stata19", "/usr/local/stata", "/usr/local/stata18", "/usr/local/stata17", "/usr/local/stata16",
                     "/usr/local/stata15")) {
           df <- paste(d, f, sep="/")
           if (file.exists(df)) {


### PR DESCRIPTION
Hi Doug

My Uni just got Stata 19.

I have run the Windows, macOS, and Linux installers.

In fact StataCorp. have changed the default installation directories on Windows and macOS and have some new suggestions on Linux.

So in this PR I have added the new default directories (it looks like your Uni IT modified the default Windows installation directory).

Of course users can already overcome this with the settings options you've provided, but it feels helpful that we should cater for the new defaults.

Here are screenshots from the installers as proof.

Windows:
<img width="650" height="685" alt="unnamed (1)" src="https://github.com/user-attachments/assets/bd1acb9f-a376-4087-9f64-f5c364e17c56" />


macOS (screenshot from Finder, as forgot to take during install):
<img width="650" height="934" alt="unnamed (2)" src="https://github.com/user-attachments/assets/af5de679-2cdb-4d0d-a41c-b80a556bb452" />


Linux:
<img width="650" height="288" alt="unnamed" src="https://github.com/user-attachments/assets/4cd04198-1964-466c-9b1c-296d593cb41a" />

All the best
Tom
