### PR TITLE
Fix a warning, a small bug, and some efficiencies

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^vignettes$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 .DS_Store
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Statamarkdown
-Version: 0.9.6
+Version: 0.9.7
 Date: 2025-10-07
 Title: 'Stata' Markdown
 Description: Settings and functions to extend the 'knitr' 'Stata' engine.

--- a/R/misc.r
+++ b/R/misc.r
@@ -1,6 +1,6 @@
 # When the package loads
 .onAttach <- function (libname, pkgname) {
-  # Redfine the 'stata' engine
+  # Redefine the 'stata' engine
   knitr::knit_engines$set(stata=stata_engine)
 
   # Find the Stata executable

--- a/R/misc.r
+++ b/R/misc.r
@@ -15,7 +15,7 @@
   knitr::opts_chunk$set(error=TRUE, cleanlog=TRUE, comment=NA, noisy=FALSE)
 
   # Hook to place collected chunk contents in a profile.do file
-  stata_collectcode()
+  stata_collectcode(stataexe)
 
   packageStartupMessage("The 'stata' engine is ready to use.")
 }

--- a/R/stata_collectcode.r
+++ b/R/stata_collectcode.r
@@ -1,9 +1,10 @@
-stata_collectcode <- function() {
+stata_collectcode <- function(stataexe) {
   # Message when Statamarkdown loads
-  if (file.exists(file.path(dirname(find_stata(message=FALSE)), "sysprofile.do"))) {
+  statadir <- dirname(stataexe)
+  if (file.exists(file.path(statadir, "sysprofile.do"))) {
     packageStartupMessage("Found a 'sysprofile.do'")
   }
-  if (file.exists(file.path(dirname(find_stata(message=FALSE)), "profile.do"))) {
+  if (file.exists(file.path(statadir, "profile.do"))) {
     packageStartupMessage("Found a 'profile.do' in the STATA executable directory.")
     packageStartupMessage("  This prevents 'collectcode' from working.")
     packageStartupMessage("  Please rename this 'sysprofile.do'.")

--- a/R/stata_collectcode.r
+++ b/R/stata_collectcode.r
@@ -20,6 +20,8 @@ stata_collectcode <- function() {
   else {
     oprofile <- NULL
   }
+  knitr_frame <- if (utils::packageVersion('knitr') >= '1.45') -10L else -9L
+
   # Hook for code processing
   knitr::knit_hooks$set(collectcode = function(before, options, envir) {
     if (!before) {
@@ -35,26 +37,14 @@ stata_collectcode <- function() {
             close(autoexec)
 # print(sys.frames())
 # print(sys.calls())
-          if (utils::packageVersion('knitr') < '1.45') {
-              do.call("on.exit",
-                      list(quote(unlink("profile.do")), add=TRUE),
-                      envir = sys.frame(-9))
-            } else if (utils::packageVersion('knitr') >= '1.45') {
-              do.call("on.exit",
-                      list(quote(unlink("profile.do")), add=TRUE),
-                      envir = sys.frame(-10))
-            }
+          do.call("on.exit",
+                  list(quote(unlink("profile.do")), add=TRUE),
+                  envir = sys.frame(knitr_frame))
 
         if (!is.null(oprofile)) { # replace the original "profile.do"
-          if (utils::packageVersion('knitr') < '1.45') {
-            do.call("on.exit",
-                    list(quote(writeLines(oprofile, "profile.do")), add=TRUE),
-                    envir = sys.frame(-9))
-          } else if (utils::packageVersion('knitr') >= '1.45') {
-            do.call("on.exit",
-                    list(quote(writeLines(oprofile, "profile.do")), add=TRUE),
-                    envir = sys.frame(-10))
-          }
+          do.call("on.exit",
+                  list(quote(writeLines(oprofile, "profile.do")), add=TRUE),
+                  envir = sys.frame(knitr_frame))
 # sys.frame(1) or sys.frame(-10) is rmarkdown::render()
 # sys.frame(-9) is knitr::knit()
         }

--- a/R/stata_engine.r
+++ b/R/stata_engine.r
@@ -28,12 +28,13 @@ stata_engine <- function (options)
     logf = sub("[.]do$", ".log", f)
     if (is.null(options$savedo) || options$savedo==FALSE)
       on.exit(unlink(logf), add = TRUE)
-    paste(switch(Sys.info()[["sysname"]],
+    sysname <- Sys.info()[["sysname"]]
+    paste(switch(sysname,
                  Windows = "/q /e do",
                  Darwin = "-q -e do",
                  Linux = "-q -b do",
                  "-q -b do"),
-          switch(Sys.info()[["sysname"]],
+          switch(sysname,
                  Windows = shQuote(normalizePath(f)),
                  Darwin = paste0("\'\"", normalizePath(f), "\"\'"),
                  Linux  = paste0("\'\"", normalizePath(f), "\"\'"),

--- a/R/stata_engine.r
+++ b/R/stata_engine.r
@@ -42,7 +42,7 @@ stata_engine <- function (options)
 
   if (is.list(options$engine.opts)) {
     code = paste(options$engine.opts[[options$engine]], code, options$doargs)
-  } else { # backwards compatability
+  } else { # backwards compatibility
     code = paste(options$engine.opts, code, options$doargs)
   }
 # print(code)
@@ -50,7 +50,7 @@ stata_engine <- function (options)
   cmd = options$engine.path
   if (is.list(options$engine.path)) {
     cmd = options$engine.path[[options$engine]]
-  } else { # backwards compatability
+  } else { # backwards compatibility
     cmd = options$engine.path
   }
 

--- a/R/stata_engine.r
+++ b/R/stata_engine.r
@@ -55,7 +55,7 @@ stata_engine <- function (options)
   }
 
   out = if (!all(options$eval==FALSE)) {
-    if (!is.null(options$noisey) && options$noisey==TRUE) message("running: ", cmd, " ", code)
+    if (!is.null(options$noisy) && options$noisy==TRUE) message("running: ", cmd, " ", code)
     tryCatch(system2(cmd, code, stdout = TRUE, stderr = TRUE,
                      env = options$engine.env), error = function(e) {
                        if (!options$error)

--- a/R/stata_engine_output.r
+++ b/R/stata_engine_output.r
@@ -27,22 +27,14 @@ stata_engine_output <- function(x, options) {
           loopcommands <- grep("^[[:space:]]+[[:digit:]]+\\.", y)
         }
         if (length(commandlines)>0 && length(loopcommands)>0) {
-          for (i in 1:length(loopcommands)) {
-            if ((loopcommands[i]-1) %in% commandlines) {
-              commandlines <- c(commandlines, loopcommands[i])
-            }
-          }
+          commandlines <- c(commandlines, loopcommands[(loopcommands - 1L) %in% commandlines])
         }
         # Long command lines are wrapped, with an initial ">"
         if (length(commandlines)>0) {
           continuations <- grep("^>[[:space:]]", y)
         }
         if (length(commandlines)>0 && length(continuations)>0) {
-          for (i in 1:length(continuations)) {
-            if ((continuations[i]-1) %in% commandlines) {
-              commandlines <- c(commandlines, continuations[i])
-            }
-          }
+          commandlines <- c(commandlines, continuations[(continuations - 1L) %in% commandlines])
         }
         # remove
         if (length(commandlines)>0) {y <- y[-(commandlines)]}

--- a/R/stata_engine_output.r
+++ b/R/stata_engine_output.r
@@ -57,7 +57,8 @@ stata_engine_output <- function(x, options) {
       if (length(y)>0 && y[length(y)] != "") { y <- c(y, "") }
 
       # Remove blank lines at the top of any Stata log
-      firsttext <- min(grep("[[:alnum:]]", y))
+      alnum_lines <- grep("[[:alnum:]]", y)
+      firsttext <- if (length(alnum_lines) > 0) min(alnum_lines) else Inf
       if (firsttext != Inf && firsttext != 1) {
         y <- y[-(1:(firsttext-1))]
         }

--- a/man/find_stata.Rd
+++ b/man/find_stata.Rd
@@ -9,7 +9,7 @@ automatically when \pkg{Statamarkdown} is loaded.
 This function searches for recent versions of Stata (>= Stata 11),
 in some of the usual default installation locations.
 
-If Stata is not found, you will have to specify it's
+If Stata is not found, you will have to specify its
 correct location yourself.
 
 }

--- a/man/spinstata.Rd
+++ b/man/spinstata.Rd
@@ -4,8 +4,8 @@
 Convert a specially marked up Stata "do" file to Markdown and HTML.
 }
 \description{
-This function takes a Stata file containing special mark up in
-it's comments, and converts it to
+This function takes a Stata file containing special markup in
+its comments, and converts it to
 Markdown and HTML documents (or one of several other formats).
 }
 \usage{
@@ -13,15 +13,15 @@ spinstata(statafile, text=NULL, keep=FALSE, ...)
 }
 \arguments{
 \item{statafile}{A character string with the name of a Stata
-"do" file, containing markup in it's comments.}
+"do" file, containing markup in its comments.}
 \item{text}{A character string in place of a file.}
 \item{keep}{Whether to save intermediate files.}
 \item{...}{options passed to \code{knitr::spin}}
 }
 
 \details{
-This function takes a Stata file containing special mark up in
-it's comments, and converts it into knitr's "spin" format.
+This function takes a Stata file containing special markup in
+its comments, and converts it into knitr's "spin" format.
 This is in turn sent to \code{knitr::spin}, and converted to
 Markdown and HTML (or one of several other formats).
 

--- a/vignettes/basicuse.rmd
+++ b/vignettes/basicuse.rmd
@@ -21,7 +21,7 @@ Your first code chunk will look something like this:
     ```
     
 This will either report that Stata was found, or
-that you need to specify it\'s location yourself.
+that you need to specify its location yourself.
 ```{r library}
 library(Statamarkdown)
 ```

--- a/vignettes/basicuse.rmd
+++ b/vignettes/basicuse.rmd
@@ -40,7 +40,7 @@ stataexe <- "C:/Program Files/Stata18/StataSE-64.exe" # Windows
 knitr::opts_chunk$set(engine.path = list(stata = stataexe))
 ```
 
-If you do not know where to find you Stata executable (app),
+If you do not know where to find your Stata executable (app),
 open Stata and issue the command `sysdir`.  The line labeled 
 `STATA: ` is the folder where your Stata executable is located. 
 You can browse there with your computer\'s file explorer to 


### PR DESCRIPTION
Hi Doug,

I hope this finds you well. I've suggested some small amends and fixes for efficiency.

* Small bug fix: `options$noisy` was accidentally misspelled as `options$noisey` in `stata_engine.r` - meaning it didn't work.
* Warning fix: When rendering a document with a chunk that emitted no output we accidentally issued this warning `no non-missing arguments to min; returning Inf`. This has always disconcerted me - have fixed.
* Fixed some typos.
* `utils::packageVersion('knitr')` was being called up to four times on every Stata chunk execution, I've got this down to one time.
* `find_stata()` was called twice redundantly in `stata_collectcode()` - have fixed.
* Two `for` loops that grew the `commandlines` vector with `c()` on each iteration are now single vectorized expressions.
* `Sys.info()[["sysname"]]` was called twice per chunk in `stata_engine.r`; it is now cached in a local variable.
* I've also bumped the version number.

(Obvs do amend as you like; or I can make changes.)

All best,
Tom